### PR TITLE
Added a CI/CD workflow for PyPI

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,64 @@
+name: Build and Publish to PyPI
+
+on:
+    push:
+        tags:
+            - 'v*'
+    workflow_dispatch:  # Allow manual triggering
+
+jobs:
+    build:
+        name: Build wheels on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+            fail-fast: false
+
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                persist-credentials: false
+
+            - name: Set up Python
+              uses: actions/setup-python@v6
+              with:
+                python-version: '3.12'
+            
+            - name: Install UV
+              uses: astral-sh/setup-uv@v7
+
+            - name: Build wheels
+              run: uv build
+            
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v7
+              with:
+                name: dist-${{ matrix.os }}
+                path: dist/
+
+    publish:
+        name: Publish to TestPyPI
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: testpypi
+            url: https://test.pypi.org/p/textual-system-monitor
+
+        steps:
+            - uses: actions/download-artifact@v8
+              with:
+                merge-multiple: true
+                path: dist/
+
+            - name: Publish to TestPyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                repository-url: https://test.pypi.org/legacy/
+                password: ${{ secrets.TESTPYPI_API_TOKEN }}
+
+            # Optional: publish to PyPI
+            # - name: Publish to PyPI
+            #   uses: pypa/gh-action-pypi-publish@release/v1
+            #   with:
+            #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,6 +6,9 @@ on:
             - 'v*'
     workflow_dispatch:  # Allow manual triggering
 
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Build wheels on ${{ matrix.os }}


### PR DESCRIPTION
Added a CI/CD workflow to handle building the package and publishing to PyPI. Only TestPyPI is supported now.
Must tag with `git tag v<VERSION>`  and `git push origin v<VERSION>` to use.